### PR TITLE
COMPONENTS: Switch Case Component

### DIFF
--- a/PrettyBlazor.Tests/Iterations/IterationTests.Render.cs
+++ b/PrettyBlazor.Tests/Iterations/IterationTests.Render.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Bunit;
-using Bunit.Rendering;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Xunit;

--- a/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
+++ b/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
@@ -45,15 +45,27 @@ namespace PrettyBlazor.Tests.Switchs
 
             RenderFragment matchingFragment = builder =>
             {
-                builder.OpenElement(0, "p");
-                builder.AddContent(1, inputMatchContent);
+                builder.OpenElement(
+                    sequence: 0,
+                    elementName: "p");
+
+                builder.AddContent(
+                    sequence: 1,
+                    textContent: inputMatchContent);
+
                 builder.CloseElement();
             };
 
             RenderFragment nonMatchingFragment = builder =>
             {
-                builder.OpenElement(0, "p");
-                builder.AddContent(1, inputNotMatchContent);
+                builder.OpenElement(
+                    sequence: 0,
+                    elementName: "p");
+
+                builder.AddContent(
+                    sequence: 1,
+                    textContent: inputNotMatchContent);
+
                 builder.CloseElement();
             };
 
@@ -125,15 +137,27 @@ namespace PrettyBlazor.Tests.Switchs
 
             RenderFragment defaultFragment = builder =>
             {
-                builder.OpenElement(0, "p");
-                builder.AddContent(1, inputDefaultContent);
+                builder.OpenElement(
+                    sequence: 0,
+                    elementName: "p");
+
+                builder.AddContent(
+                    sequence: 1,
+                    textContent: inputDefaultContent);
+
                 builder.CloseElement();
             };
 
             RenderFragment nonMatchingCaseFragment = builder =>
             {
-                builder.OpenElement(0, "p");
-                builder.AddContent(1, inputCaseContent);
+                builder.OpenElement(
+                    sequence: 0,
+                    elementName: "p");
+
+                builder.AddContent(
+                    sequence: 1,
+                    textContent: inputCaseContent);
+
                 builder.CloseElement();
             };
 
@@ -147,7 +171,7 @@ namespace PrettyBlazor.Tests.Switchs
                     name: nameof(Switch<int>.ChildContent),
                     value: new RenderFragment(builder =>
                     {
-                        builder.OpenComponent<SwitchCase<int>>(0);
+                        builder.OpenComponent<SwitchCase<int>>(sequence: 0);
 
                         builder.AddAttribute(
                             sequence: 1,
@@ -161,7 +185,7 @@ namespace PrettyBlazor.Tests.Switchs
 
                         builder.CloseComponent();
 
-                        builder.OpenComponent<SwitchDefault<int>>(3);
+                        builder.OpenComponent<SwitchDefault<int>>(sequence: 3);
 
                         builder.AddAttribute(
                             sequence: 4,
@@ -199,8 +223,14 @@ namespace PrettyBlazor.Tests.Switchs
 
             RenderFragment nonMatchingCaseFragment = builder =>
             {
-                builder.OpenElement(0, "p");
-                builder.AddContent(1, inputCaseContent);
+                builder.OpenElement(
+                    sequence: 0,
+                    elementName: "p");
+
+                builder.AddContent(
+                    sequence: 1,
+                    textContent: inputCaseContent);
+
                 builder.CloseElement();
             };
 
@@ -214,7 +244,7 @@ namespace PrettyBlazor.Tests.Switchs
                     name: nameof(Switch<int>.ChildContent),
                     value: new RenderFragment(builder =>
                     {
-                        builder.OpenComponent<SwitchCase<int>>(0);
+                        builder.OpenComponent<SwitchCase<int>>(sequence: 0);
 
                         builder.AddAttribute(
                             sequence: 1,

--- a/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
+++ b/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
@@ -1,0 +1,25 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using FluentAssertions;
+using Xunit;
+
+namespace PrettyBlazor.Tests.Switchs
+{
+    public partial class SwitchTests
+    {
+        [Fact]
+        public void ShouldHaveDefaultInitParametersForSwitch()
+        {
+            // when
+            var component = new Switch<string>();
+
+            // then
+            component.Value.Should().BeNull();
+            component.ChildContent.Should().BeNull();
+        }
+    }
+}

--- a/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
+++ b/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
@@ -77,9 +77,9 @@ namespace PrettyBlazor.Tests.Switchs
 
                 ComponentParameter.CreateParameter(
                     name: nameof(Switch<int>.ChildContent),
-                    value:new RenderFragment(builder =>
+                    value: new RenderFragment(builder =>
                 {
-                    builder.OpenComponent<SwitchCase<int>>(0);
+                    builder.OpenComponent<SwitchCase<int>>(sequence: 0);
 
                     builder.AddAttribute(
                         sequence: 1,
@@ -109,11 +109,12 @@ namespace PrettyBlazor.Tests.Switchs
             };
 
             // when
-            var rendered = RenderComponent<Switch<int>>(parameters);
+            IRenderedComponent<Switch<int>> renderedComponent =
+                RenderComponent<Switch<int>>(parameters);
 
             // then
-            rendered.Markup.Should().Contain(expectedMatchContent);
-            rendered.Markup.Should().NotContain(unexpectedNotMatchContent);
+            renderedComponent.Markup.Should().Contain(expectedMatchContent);
+            renderedComponent.Markup.Should().NotContain(unexpectedNotMatchContent);
         }
 
         [Fact]
@@ -197,11 +198,12 @@ namespace PrettyBlazor.Tests.Switchs
             };
 
             // when
-            var rendered = RenderComponent<Switch<int>>(parameters);
+            IRenderedComponent<Switch<int>> renderedComponent =
+                RenderComponent<Switch<int>>(parameters);
 
             // then
-            rendered.Markup.Should().Contain(expectedDefaultContent);
-            rendered.Markup.Should().NotContain(unexpectedCaseContent);
+            renderedComponent.Markup.Should().Contain(expectedDefaultContent);
+            renderedComponent.Markup.Should().NotContain(unexpectedCaseContent);
         }
 
         [Fact]
@@ -261,11 +263,12 @@ namespace PrettyBlazor.Tests.Switchs
             };
 
             // when
-            var rendered = RenderComponent<Switch<int>>(parameters);
+            IRenderedComponent<Switch<int>> renderedComponent =
+                RenderComponent<Switch<int>>(parameters);
 
             // then
-            rendered.Markup.Trim().Should().BeEmpty();
-            rendered.Markup.Should().NotContain(unexpectedCaseContent);
+            renderedComponent.Markup.Trim().Should().BeEmpty();
+            renderedComponent.Markup.Should().NotContain(unexpectedCaseContent);
         }
     }
 }

--- a/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
+++ b/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
@@ -366,12 +366,13 @@ namespace PrettyBlazor.Tests.Switchs
             };
 
             // when
-            var rendered = RenderComponent<Switch<int>>(parameters);
+            IRenderedComponent<Switch<int>> renderedComponent =
+                RenderComponent<Switch<int>>(parameters);
 
             // then
-            rendered.Markup.Should().Contain(matchContent);
-            rendered.Markup.Should().NotContain(defaultContent);
-            rendered.Markup.Should().NotContain("This should not be shown");
+            renderedComponent.Markup.Should().Contain(matchContent);
+            renderedComponent.Markup.Should().NotContain(defaultContent);
+            renderedComponent.Markup.Should().NotContain("This should not be shown");
         }
     }
 }

--- a/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
+++ b/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
@@ -38,17 +38,19 @@ namespace PrettyBlazor.Tests.Switchs
 
             int inputMatchValue = randomMatchValue;
             int inputNotMatchValue = randomNotMatchValue;
+            string inputMatchContent = "This should be rendered";
             string inputNotMatchContent = "This should not be rendered";
-            string expectedMatchContent = "Test View: int";
+            string expectedMatchContent = inputMatchContent;
             string unexpectedNotMatchContent = inputNotMatchContent;
 
-            RenderFragment<int> matchingFragment = val => builder =>
+            RenderFragment matchingFragment = builder =>
             {
-                builder.OpenComponent(0, typeof(SomeSwitchViewComponent<int>));
-                builder.CloseComponent();
+                builder.OpenElement(0, "p");
+                builder.AddContent(1, inputMatchContent);
+                builder.CloseElement();
             };
 
-            RenderFragment<int> nonMatchingFragment = val => builder =>
+            RenderFragment nonMatchingFragment = builder =>
             {
                 builder.OpenElement(0, "p");
                 builder.AddContent(1, inputNotMatchContent);
@@ -62,7 +64,7 @@ namespace PrettyBlazor.Tests.Switchs
                     value: inputMatchValue),
 
                 ComponentParameter.CreateParameter(
-                    name: nameof(Switch<string>.ChildContent),
+                    name: nameof(Switch<int>.ChildContent),
                     value:new RenderFragment(builder =>
                 {
                     builder.OpenComponent<SwitchCase<int>>(0);

--- a/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
+++ b/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
@@ -4,7 +4,9 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
+using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components;
 using Xunit;
 
 namespace PrettyBlazor.Tests.Switchs
@@ -20,6 +22,84 @@ namespace PrettyBlazor.Tests.Switchs
             // then
             component.Value.Should().BeNull();
             component.ChildContent.Should().BeNull();
+        }
+
+        [Fact]
+        public void ShouldRenderOnlyMatchingSwitchCase()
+        {
+            // given
+            int randomMatchValue = GetRandomNumber();
+            int randomNotMatchValue = GetRandomNumber();
+
+            while (randomMatchValue == randomNotMatchValue)
+            {
+                randomNotMatchValue = GetRandomNumber();
+            }
+
+            int inputMatchValue = randomMatchValue;
+            int inputNotMatchValue = randomNotMatchValue;
+            string inputNotMatchContent = "This should not be rendered";
+            string expectedMatchContent = "Test View: int";
+            string unexpectedNotMatchContent = inputNotMatchContent;
+
+            RenderFragment<int> matchingFragment = val => builder =>
+            {
+                builder.OpenComponent(0, typeof(SomeSwitchViewComponent<int>));
+                builder.CloseComponent();
+            };
+
+            RenderFragment<int> nonMatchingFragment = val => builder =>
+            {
+                builder.OpenElement(0, "p");
+                builder.AddContent(1, inputNotMatchContent);
+                builder.CloseElement();
+            };
+
+            var parameters = new ComponentParameter[]
+            {
+                ComponentParameter.CreateParameter(
+                    name: nameof(Switch<int>.Value),
+                    value: inputMatchValue),
+
+                ComponentParameter.CreateParameter(
+                    name: nameof(Switch<string>.ChildContent),
+                    value:new RenderFragment(builder =>
+                {
+                    builder.OpenComponent<SwitchCase<int>>(0);
+
+                    builder.AddAttribute(
+                        sequence: 1,
+                        name: nameof(SwitchCase<int>.When),
+                        value: inputNotMatchValue);
+
+                    builder.AddAttribute(
+                        sequence: 2,
+                        name: nameof(SwitchCase<int>.ChildContent),
+                        value: nonMatchingFragment);
+
+                    builder.CloseComponent();
+                    builder.OpenComponent<SwitchCase<int>>(3);
+
+                    builder.AddAttribute(
+                        sequence: 4,
+                        name: nameof(SwitchCase<int>.When),
+                        value: inputMatchValue);
+
+                    builder.AddAttribute(
+                        sequence: 5,
+                        name: nameof(SwitchCase<int>.ChildContent),
+                        value: matchingFragment);
+
+                    builder.CloseComponent();
+                }))
+            };
+
+            // when
+            var rendered = RenderComponent<Switch<int>>(parameters);
+
+            // then
+            rendered.Markup.Should().Contain(expectedMatchContent);
+            rendered.Markup.Should().NotContain(unexpectedNotMatchContent);
         }
     }
 }

--- a/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
+++ b/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
@@ -179,5 +179,63 @@ namespace PrettyBlazor.Tests.Switchs
             rendered.Markup.Should().Contain(expectedDefaultContent);
             rendered.Markup.Should().NotContain(unexpectedCaseContent);
         }
+
+        [Fact]
+        public void ShouldRenderNothingWhenNoMatchAndNoDefault()
+        {
+            // given
+            int randomSwitchValue = GetRandomNumber();
+            int randomCaseValue = GetRandomNumber();
+
+            while (randomSwitchValue == randomCaseValue)
+            {
+                randomCaseValue = GetRandomNumber();
+            }
+
+            int inputSwitchValue = randomSwitchValue;
+            int inputCaseValue = randomCaseValue;
+            string inputCaseContent = "This should not be rendered";
+            string unexpectedCaseContent = inputCaseContent;
+
+            RenderFragment nonMatchingCaseFragment = builder =>
+            {
+                builder.OpenElement(0, "p");
+                builder.AddContent(1, inputCaseContent);
+                builder.CloseElement();
+            };
+
+            var parameters = new ComponentParameter[]
+            {
+                ComponentParameter.CreateParameter(
+                    name: nameof(Switch<int>.Value),
+                    value: inputSwitchValue),
+
+                ComponentParameter.CreateParameter(
+                    name: nameof(Switch<int>.ChildContent),
+                    value: new RenderFragment(builder =>
+                    {
+                        builder.OpenComponent<SwitchCase<int>>(0);
+
+                        builder.AddAttribute(
+                            sequence: 1,
+                            name: nameof(SwitchCase<int>.When),
+                            value: inputCaseValue);
+
+                        builder.AddAttribute(
+                            sequence: 2,
+                            name: nameof(SwitchCase<int>.ChildContent),
+                            value: nonMatchingCaseFragment);
+
+                        builder.CloseComponent();
+                    }))
+            };
+
+            // when
+            var rendered = RenderComponent<Switch<int>>(parameters);
+
+            // then
+            rendered.Markup.Trim().Should().BeEmpty();
+            rendered.Markup.Should().NotContain(unexpectedCaseContent);
+        }
     }
 }

--- a/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
+++ b/PrettyBlazor.Tests/Switchs/SwitchTests.Render.cs
@@ -185,7 +185,6 @@ namespace PrettyBlazor.Tests.Switchs
                             value: nonMatchingCaseFragment);
 
                         builder.CloseComponent();
-
                         builder.OpenComponent<SwitchDefault<int>>(sequence: 3);
 
                         builder.AddAttribute(
@@ -244,6 +243,7 @@ namespace PrettyBlazor.Tests.Switchs
 
                 ComponentParameter.CreateParameter(
                     name: nameof(Switch<int>.ChildContent),
+
                     value: new RenderFragment(builder =>
                     {
                         builder.OpenComponent<SwitchCase<int>>(sequence: 0);

--- a/PrettyBlazor.Tests/Switchs/SwitchTests.cs
+++ b/PrettyBlazor.Tests/Switchs/SwitchTests.cs
@@ -13,8 +13,6 @@ namespace PrettyBlazor.Tests.Switchs
 {
     public partial class SwitchTests : TestContext
     {
-        private IRenderedComponent<Switch<int>> renderedSwitchComponent;
-
         private static int GetRandomNumber() =>
             new IntRange(min: 2, max: 10).GetValue();
 

--- a/PrettyBlazor.Tests/Switchs/SwitchTests.cs
+++ b/PrettyBlazor.Tests/Switchs/SwitchTests.cs
@@ -5,11 +5,27 @@
 // ---------------------------------------------------------------
 
 using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Tynamix.ObjectFiller;
 
 namespace PrettyBlazor.Tests.Switchs
 {
     public partial class SwitchTests : TestContext
     {
         private IRenderedComponent<Switch<int>> renderedSwitchComponent;
+
+        private static int GetRandomNumber() =>
+            new IntRange(min: 2, max: 10).GetValue();
+
+        public class SomeSwitchViewComponent<T> : ComponentBase
+        {
+            protected override void BuildRenderTree(RenderTreeBuilder builder)
+            {
+                builder.OpenElement(0, "p");
+                builder.AddContent(1, $"Switch View: {typeof(T).Name}");
+                builder.CloseElement();
+            }
+        }
     }
 }

--- a/PrettyBlazor.Tests/Switchs/SwitchTests.cs
+++ b/PrettyBlazor.Tests/Switchs/SwitchTests.cs
@@ -1,0 +1,15 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using Bunit;
+
+namespace PrettyBlazor.Tests.Switchs
+{
+    public partial class SwitchTests : TestContext
+    {
+        private IRenderedComponent<Switch<int>> renderedSwitchComponent;
+    }
+}

--- a/PrettyBlazor.Tests/Switchs/SwitchTests.cs
+++ b/PrettyBlazor.Tests/Switchs/SwitchTests.cs
@@ -14,14 +14,20 @@ namespace PrettyBlazor.Tests.Switchs
     public partial class SwitchTests : TestContext
     {
         private static int GetRandomNumber() =>
-            new IntRange(min: 2, max: 10).GetValue();
+            new IntRange(min: 2, max: 9).GetValue();
 
         public class SomeSwitchViewComponent<T> : ComponentBase
         {
             protected override void BuildRenderTree(RenderTreeBuilder builder)
             {
-                builder.OpenElement(0, "p");
-                builder.AddContent(1, $"Switch View: {typeof(T).Name}");
+                builder.OpenElement(
+                    sequence: 0,
+                    elementName: "p");
+
+                builder.AddContent(
+                    sequence: 1,
+                    textContent: $"Switch View: {typeof(T).Name}");
+
                 builder.CloseElement();
             }
         }

--- a/PrettyBlazor/License.txt
+++ b/PrettyBlazor/License.txt
@@ -3,23 +3,77 @@
 Copyright (c) 2021 Hassan Habib All rights reserved.
 
 Material in this repository is made available under the following terms:
-  1. Code is licensed under the MIT license, reproduced below.
-  2. Documentation is licensed under the Creative Commons Attribution 3.0 United States (Unported) License.
-     The text of the license can be found here: http://creativecommons.org/licenses/by/3.0/legalcode
+  1. Code is licensed under the TSSL v1.0 license, reproduced below. 
+     The text of the license can be found here: https://github.com/hassanhabib/The-Standard-Software-License
 
-The MIT License (MIT)
+0. Ethical Use Condition
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-associated documentation files (the "Software"), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute,
-sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Software under this license may be used for personal or commercial purposes.
+We encourage its use for humanitarian efforts and projects that serve the survival, evolution, and fulfillment of mankind.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial
-portions of the Software.
+However, this software may not be used, directly or indirectly, in any project that contributes to or facilitates:
 
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
-OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- The threatening of human survival,
+- The hindrance of human evolution,
+- The diminishment of human fulfillment.
+- This ethical condition is non-negotiable and applies to all users, distributors, and modifiers.
+
+1. Freedom and Sharing
+
+Software under this license is free as in free tea and free speech.
+
+It is encouraged to be:
+
+- Used freely, as long as the Ethical Use Condition is upheld.
+- Modified to improve and adapt it to new use cases.
+- Distributed in original or modified form.
+- Studied and learned from as a tool for innovation and education.
+
+2. License and Attribution
+
+- This license must remain attached to all original and modified versions of the software.
+- If you modify this software, you must clearly state your changes.
+- You may not misrepresent the origin of the software or claim original authorship of unmodified parts.
+
+3. AI and Automation
+
+If this software is used in artificial intelligence systems, automated decision-making, or data-driven platforms, the implementers must:
+
+- Evaluate the application’s compliance with the Ethical Use Condition (section 0),
+- Mitigate any foreseeable risks that may violate that condition,
+- Document how the use aligns with the license’s ethical principles.
+
+4. Irrevocability and Permanence of Freedom
+
+- This license is perpetual and irrevocable.
+- Once software is released under this license, the author cannot revoke, re-license, or retroactively restrict its freedoms.
+- Future versions of The Standard Software License may be released to clarify or extend its terms, but existing licensed software remains bound to its original version.
+
+5. Commercial Use and Non-Monetization of the Licensed Software
+
+- You may use this software in commercial projects, businesses, and for-profit environments.
+- You may charge for services (e.g. support, consulting, hosting, integrations) built around this software.
+- However, you may not sell, license, or charge for access, usage, distribution, or copies of the software itself.
+
+You can profit with it, but not from it directly.
+
+This ensures that once made free, the software remains free forever—regardless of popularity or success.
+
+6. Derivative and Combined Works
+
+If this software is combined with other software, the portions under this license must continue to follow these terms, including the Ethical Use Condition and Non-Monetization rule.
+Derivative works must clearly separate code under this license if the resulting project uses different licensing for other components.
+
+7. No Warranty
+
+This software is provided "as-is", without warranty of any kind.
+The authors are not liable for any damages or misuse, except where such liability arises from intentional violation of the Ethical Use Condition.
+
+TL;DR
+
+✅ Use it personally or commercially
+✅ Learn, teach, modify, share
+✅ Use it to help humanity
+❌ Don’t charge for the software itself
+❌ Don’t use it for harm
+🚫 You can’t take the freedom back later

--- a/PrettyBlazor/Switch.razor
+++ b/PrettyBlazor/Switch.razor
@@ -1,5 +1,7 @@
-@typeparam T
+@typeparam TValue
 
-<CascadingValue Value="Value" Name="SwitchValue">
+<CascadingValue Value="Value"
+                Name="SwitchValue">
+
     @ChildContent
 </CascadingValue>

--- a/PrettyBlazor/Switch.razor
+++ b/PrettyBlazor/Switch.razor
@@ -1,0 +1,5 @@
+@typeparam T
+
+<CascadingValue Value="Value" Name="SwitchValue">
+    @ChildContent
+</CascadingValue>

--- a/PrettyBlazor/Switch.razor
+++ b/PrettyBlazor/Switch.razor
@@ -1,7 +1,7 @@
 @typeparam TValue
 
-<CascadingValue Value="Value"
-                Name="SwitchValue">
-
-    @ChildContent
+<CascadingValue Value="Value">
+    <CascadingValue Value="this">
+        @ChildContent
+    </CascadingValue>
 </CascadingValue>

--- a/PrettyBlazor/Switch.razor.cs
+++ b/PrettyBlazor/Switch.razor.cs
@@ -1,0 +1,21 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using Microsoft.AspNetCore.Components;
+
+namespace PrettyBlazor
+{
+    public partial class Switch<T> : ComponentBase
+    {
+        internal static T CurrentValue;
+
+        [Parameter]
+        public T Value { get; set; }
+
+        [Parameter]
+        public RenderFragment ChildContent { get; set; }
+    }
+}

--- a/PrettyBlazor/Switch.razor.cs
+++ b/PrettyBlazor/Switch.razor.cs
@@ -8,10 +8,10 @@ using Microsoft.AspNetCore.Components;
 
 namespace PrettyBlazor
 {
-    public partial class Switch<T> : ComponentBase
+    public partial class Switch<TValue> : ComponentBase
     {
         [Parameter]
-        public T Value { get; set; }
+        public TValue Value { get; set; }
 
         [Parameter]
         public RenderFragment ChildContent { get; set; }

--- a/PrettyBlazor/Switch.razor.cs
+++ b/PrettyBlazor/Switch.razor.cs
@@ -15,5 +15,10 @@ namespace PrettyBlazor
 
         [Parameter]
         public RenderFragment ChildContent { get; set; }
+
+        internal bool HasMatchedCase { get; private set; }
+
+        internal void NotifyMatched() =>
+            this.HasMatchedCase = true;
     }
 }

--- a/PrettyBlazor/Switch.razor.cs
+++ b/PrettyBlazor/Switch.razor.cs
@@ -10,8 +10,6 @@ namespace PrettyBlazor
 {
     public partial class Switch<T> : ComponentBase
     {
-        internal static T CurrentValue;
-
         [Parameter]
         public T Value { get; set; }
 

--- a/PrettyBlazor/SwitchCase.razor
+++ b/PrettyBlazor/SwitchCase.razor
@@ -1,4 +1,4 @@
-@typeparam T
+@typeparam TValue
 
 @if (ShouldRenderCase())
 {

--- a/PrettyBlazor/SwitchCase.razor
+++ b/PrettyBlazor/SwitchCase.razor
@@ -1,0 +1,6 @@
+@typeparam T
+
+@if (ShouldRenderCase())
+{
+    @ChildContent
+}

--- a/PrettyBlazor/SwitchCase.razor.cs
+++ b/PrettyBlazor/SwitchCase.razor.cs
@@ -14,8 +14,10 @@ namespace PrettyBlazor
         [CascadingParameter(Name = "SwitchValue")]
         public T SwitchValue { get; set; }
 
-        [Parameter] public T When { get; set; }
-        [Parameter] public RenderFragment ChildContent { get; set; }
+        [Parameter]
+        public T When { get; set; }
+        [Parameter]
+        public RenderFragment ChildContent { get; set; }
 
         private bool ShouldRenderCase() =>
             EqualityComparer<T>.Default.Equals(SwitchValue, When);

--- a/PrettyBlazor/SwitchCase.razor.cs
+++ b/PrettyBlazor/SwitchCase.razor.cs
@@ -11,8 +11,11 @@ namespace PrettyBlazor
 {
     public partial class SwitchCase<TValue> : ComponentBase
     {
-        [CascadingParameter(Name = "SwitchValue")]
-        public TValue SwitchValue { get; set; }
+        [CascadingParameter]
+        public TValue Value { get; set; }
+
+        [CascadingParameter]
+        public Switch<TValue> Switch { get; set; }
 
         [Parameter]
         public TValue When { get; set; }
@@ -20,10 +23,18 @@ namespace PrettyBlazor
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 
+        protected override void OnParametersSet()
+        {
+            if (ShouldRenderCase())
+            {
+                Switch?.NotifyMatched();
+            }
+        }
+
         private bool ShouldRenderCase()
         {
             return EqualityComparer<TValue>.Default.Equals(
-                x: SwitchValue,
+                x: Value,
                 y: When);
         }
     }

--- a/PrettyBlazor/SwitchCase.razor.cs
+++ b/PrettyBlazor/SwitchCase.razor.cs
@@ -1,0 +1,23 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
+
+namespace PrettyBlazor
+{
+    public partial class SwitchCase<T> : ComponentBase
+    {
+        [CascadingParameter(Name = "SwitchValue")]
+        public T SwitchValue { get; set; }
+
+        [Parameter] public T When { get; set; }
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        private bool ShouldRenderCase() =>
+            EqualityComparer<T>.Default.Equals(SwitchValue, When);
+    }
+}

--- a/PrettyBlazor/SwitchCase.razor.cs
+++ b/PrettyBlazor/SwitchCase.razor.cs
@@ -16,6 +16,7 @@ namespace PrettyBlazor
 
         [Parameter]
         public T When { get; set; }
+
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 

--- a/PrettyBlazor/SwitchCase.razor.cs
+++ b/PrettyBlazor/SwitchCase.razor.cs
@@ -27,15 +27,15 @@ namespace PrettyBlazor
         {
             if (ShouldRenderCase())
             {
-                Switch?.NotifyMatched();
+                this.Switch?.NotifyMatched();
             }
         }
 
         private bool ShouldRenderCase()
         {
             return EqualityComparer<TValue>.Default.Equals(
-                x: Value,
-                y: When);
+                x: this.Value,
+                y: this.When);
         }
     }
 }

--- a/PrettyBlazor/SwitchCase.razor.cs
+++ b/PrettyBlazor/SwitchCase.razor.cs
@@ -9,18 +9,22 @@ using Microsoft.AspNetCore.Components;
 
 namespace PrettyBlazor
 {
-    public partial class SwitchCase<T> : ComponentBase
+    public partial class SwitchCase<TValue> : ComponentBase
     {
         [CascadingParameter(Name = "SwitchValue")]
-        public T SwitchValue { get; set; }
+        public TValue SwitchValue { get; set; }
 
         [Parameter]
-        public T When { get; set; }
+        public TValue When { get; set; }
 
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 
-        private bool ShouldRenderCase() =>
-            EqualityComparer<T>.Default.Equals(SwitchValue, When);
+        private bool ShouldRenderCase()
+        {
+            return EqualityComparer<TValue>.Default.Equals(
+                x: SwitchValue,
+                y: When);
+        }
     }
 }

--- a/PrettyBlazor/SwitchDefault.razor
+++ b/PrettyBlazor/SwitchDefault.razor
@@ -1,0 +1,6 @@
+@typeparam T
+
+@if (ShouldRenderDefaultCase())
+{
+    @ChildContent
+}

--- a/PrettyBlazor/SwitchDefault.razor
+++ b/PrettyBlazor/SwitchDefault.razor
@@ -1,4 +1,4 @@
-@typeparam T
+@typeparam TValue
 
 @if (ShouldRenderDefaultCase())
 {

--- a/PrettyBlazor/SwitchDefault.razor.cs
+++ b/PrettyBlazor/SwitchDefault.razor.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
+
+namespace PrettyBlazor
+{
+    public partial class SwitchDefault<T> : ComponentBase
+    {
+        [CascadingParameter(Name = "SwitchValue")]
+        public T SwitchValue { get; set; }
+
+        [CascadingParameter] public List<T> CaseValues { get; set; }
+
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        private bool ShouldRenderDefaultCase() =>
+            CaseValues == null || !CaseValues.Contains(SwitchValue);
+    }
+}

--- a/PrettyBlazor/SwitchDefault.razor.cs
+++ b/PrettyBlazor/SwitchDefault.razor.cs
@@ -17,6 +17,6 @@ namespace PrettyBlazor
         public RenderFragment ChildContent { get; set; }
 
         private bool ShouldRenderDefaultCase() =>
-            Switch is not null && Switch.HasMatchedCase is false;
+            this.Switch is not null && this.Switch.HasMatchedCase is false;
     }
 }

--- a/PrettyBlazor/SwitchDefault.razor.cs
+++ b/PrettyBlazor/SwitchDefault.razor.cs
@@ -8,9 +8,11 @@ namespace PrettyBlazor
         [CascadingParameter(Name = "SwitchValue")]
         public T SwitchValue { get; set; }
 
-        [CascadingParameter] public List<T> CaseValues { get; set; }
+        [CascadingParameter]
+        public List<T> CaseValues { get; set; }
 
-        [Parameter] public RenderFragment ChildContent { get; set; }
+        [Parameter]
+        public RenderFragment ChildContent { get; set; }
 
         private bool ShouldRenderDefaultCase() =>
             CaseValues == null || !CaseValues.Contains(SwitchValue);

--- a/PrettyBlazor/SwitchDefault.razor.cs
+++ b/PrettyBlazor/SwitchDefault.razor.cs
@@ -9,18 +9,18 @@ using Microsoft.AspNetCore.Components;
 
 namespace PrettyBlazor
 {
-    public partial class SwitchDefault<T> : ComponentBase
+    public partial class SwitchDefault<TValue> : ComponentBase
     {
         [CascadingParameter(Name = "SwitchValue")]
-        public T SwitchValue { get; set; }
+        public TValue SwitchValue { get; set; }
 
         [CascadingParameter]
-        public List<T> CaseValues { get; set; }
+        public List<TValue> CaseValues { get; set; }
 
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 
         private bool ShouldRenderDefaultCase() =>
-            CaseValues == null || !CaseValues.Contains(SwitchValue);
+            CaseValues is null || CaseValues.Contains(SwitchValue) is false;
     }
 }

--- a/PrettyBlazor/SwitchDefault.razor.cs
+++ b/PrettyBlazor/SwitchDefault.razor.cs
@@ -4,23 +4,19 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 
 namespace PrettyBlazor
 {
     public partial class SwitchDefault<TValue> : ComponentBase
     {
-        [CascadingParameter(Name = "SwitchValue")]
-        public TValue SwitchValue { get; set; }
-
         [CascadingParameter]
-        public List<TValue> CaseValues { get; set; }
+        public Switch<TValue> Switch { get; set; }
 
         [Parameter]
         public RenderFragment ChildContent { get; set; }
 
         private bool ShouldRenderDefaultCase() =>
-            CaseValues is null || CaseValues.Contains(SwitchValue) is false;
+            Switch is not null && Switch.HasMatchedCase is false;
     }
 }

--- a/PrettyBlazor/SwitchDefault.razor.cs
+++ b/PrettyBlazor/SwitchDefault.razor.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 
 namespace PrettyBlazor

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+﻿<p align="center">
   <img width="25%" height="25%" src="https://raw.githubusercontent.com/hassanhabib/PrettyBlazor/master/PrettyBlazor/PrettyBlazor.png">
 </p>
 
@@ -129,6 +129,49 @@ The equivelant of writing the same statement in Blazor today would be:
 }
 ```
 C# mixed with html - which can become quite problematic from a readability, maintenance and performance perspectives when used in a large scale application - no matter how simpler you try to make the system components to be.
+
+## 🌟 New in PrettyBlazor: `<Switch>`, `<SwitchCase>`, and `<SwitchDefault>`
+
+PrettyBlazor now includes declarative components to replace `@switch` statements in markup. These components allow rendering different UI fragments based on a value—without C# logic interleaved in your `.razor` files.
+
+### Example
+```razor
+<Switch T="AuthorizedState" Value="ComponentState">
+    <SwitchCase T="AuthorizedState" When="AuthorizedState.Loading">
+        <p>Loading...</p>
+    </SwitchCase>
+
+    <SwitchCase T="AuthorizedState" When="AuthorizedState.Authorized">
+        <p>Welcome back!</p>
+    </SwitchCase>
+
+    <SwitchCase T="AuthorizedState" When="AuthorizedState.Error">
+        <p>Something went wrong.</p>
+    </SwitchCase>
+
+    <SwitchDefault>
+        <p>Unknown state.</p>
+    </SwitchDefault>
+</Switch>
+```
+This replaces traditional Blazor syntax like:
+```razor
+@switch (ComponentState)
+{
+    case AuthorizedState.Loading:
+        <p>Loading...</p>
+        break;
+    case AuthorizedState.Authorized:
+        <p>Welcome back!</p>
+        break;
+    case AuthorizedState.Error:
+        <p>Something went wrong.</p>
+        break;
+    default:
+        <p>Unknown state.</p>
+        break;
+}
+```
 
 ## Installation
 


### PR DESCRIPTION
Add Switch/Case/Default Components for Declarative Conditional Rendering
This PR introduces:

✅ `Switch<T>`: a generic root component to evaluate a value

✅ `SwitchCase<T>`: conditionally renders content if the value matches

✅ `SwitchDefault`: fallback rendering when no cases match

✅ Unit tests for all scenarios (matching, default, empty) using bUnit

These components enable a cleaner, more readable alternative to `@switch` blocks in Razor, fully declarative and reusable.